### PR TITLE
[#244] 테스트코드에서 redis port를 6380으로 변경한다

### DIFF
--- a/server/src/test/kotlin/com/fone/common/IntegrationTestContextInitializer.kt
+++ b/server/src/test/kotlin/com/fone/common/IntegrationTestContextInitializer.kt
@@ -1,8 +1,6 @@
 package com.fone.common
 
-import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.PortBinding
-import com.github.dockerjava.api.model.Ports
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.testcontainers.containers.GenericContainer
@@ -32,19 +30,21 @@ class IntegrationTestContextInitializer :
                 withUrlParam("useTimezone", "true")
                 withUrlParam("serverTimezone", "Asia/Seoul")
                 withCreateContainerCmdModifier {
-                    it.withPortBindings(
-                        PortBinding(Ports.Binding.bindPort(33006), ExposedPort(3306))
-                    ).withHostName("app-host")
+                    it.withPortBindings(PortBinding.parse("33006:3306"))
                 }
                 start()
             }
 
         val REDIS_CONTAINER =
-            GenericContainer(DockerImageName.parse("redis:5.0.3-alpine")).withExposedPorts(6379)
+            GenericContainer(
+                DockerImageName.parse("redis:5.0.3-alpine")
+            ).withCreateContainerCmdModifier {
+                it.withPortBindings(PortBinding.parse("6380:6379"))
+            }
 
         REDIS_CONTAINER.start()
 
-        System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost())
+        System.setProperty("spring.redis.host", REDIS_CONTAINER.host)
         System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString())
     }
 }

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -25,7 +25,7 @@ spring:
 
   redis:
     host: localhost
-    port: 6379
+    port: 6380
 
 security:
   password:


### PR DESCRIPTION
이것까지만 반영되면 기존 포트랑 겹칠일이 없어서, 테스트코드 돌릴때 기존 container를 종료 안해도 될 것 같습니다.