### PR TITLE
[#250] 트랜잭션 리팩토링

### DIFF
--- a/common/src/main/kotlin/com/fone/common/config/TransactionalConfig.kt
+++ b/common/src/main/kotlin/com/fone/common/config/TransactionalConfig.kt
@@ -1,0 +1,54 @@
+package com.fone.common.config
+
+import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMutinyReactiveQueryFactory
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.context.annotation.Configuration
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+@Aspect
+@Configuration
+class TransactionalConfig(
+    private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
+) {
+    @Around("@annotation(javax.transaction.Transactional)")
+    fun javaxTransaction(joinPoint: ProceedingJoinPoint): Any? {
+        return createTransaction(joinPoint)
+    }
+
+    @Around("@annotation(org.springframework.transaction.annotation.Transactional)")
+    fun springDataTransaction(joinPoint: ProceedingJoinPoint): Any? {
+        return createTransaction(joinPoint)
+    }
+
+    private fun createTransaction(joinPoint: ProceedingJoinPoint): Any? {
+        // continuation이 없으면 suspend 함수가 아님. 그냥 끝냄.
+        if (joinPoint.args.last() !is Continuation<*>) return joinPoint.proceed()
+        return joinPoint.runCoroutine {
+            queryFactory.transactionWithFactory { _ ->
+                joinPoint.proceedCoroutine()
+            }
+        }
+    }
+}
+
+private val ProceedingJoinPoint.coroutineContinuation: Continuation<Any?>
+    get() = this.args.last() as Continuation<Any?>
+
+private val ProceedingJoinPoint.coroutineArgs: Array<Any?>
+    get() = this.args.sliceArray(0 until this.args.size - 1)
+
+private suspend fun ProceedingJoinPoint.proceedCoroutine(
+    args: Array<Any?> = this.coroutineArgs,
+): Any? =
+    suspendCoroutineUninterceptedOrReturn { continuation -> // 마법, continuation -> COROUTINE_SUSPENDED을 돌려주게하려면 이걸 호출해야됨.
+        this.proceed(args + continuation)
+    }
+
+private fun ProceedingJoinPoint.runCoroutine(
+    block: suspend () -> Any?,
+): Any? =
+    block.startCoroutineUninterceptedOrReturn(this.coroutineContinuation)

--- a/common/src/main/kotlin/com/fone/common/config/TransactionalConfig.kt
+++ b/common/src/main/kotlin/com/fone/common/config/TransactionalConfig.kt
@@ -14,7 +14,7 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 class TransactionalConfig(
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
 ) {
-    @Around("@annotation(javax.transaction.Transactional)")
+    @Around("@annotation(javax.transaction.Transactional)") // Spring 3부터 jakarta
     fun javaxTransaction(joinPoint: ProceedingJoinPoint): Any? {
         return createTransaction(joinPoint)
     }

--- a/server/src/test/kotlin/com/fone/report/domain/repository/TestReportRepositoryImpl.kt
+++ b/server/src/test/kotlin/com/fone/report/domain/repository/TestReportRepositoryImpl.kt
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Repository
 @Repository
 @Primary
 class TestReportRepositoryImpl(
-    private val sessionFactory: Mutiny.SessionFactory,
-    private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
+    val sessionFactory: Mutiny.SessionFactory,
+    val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
 ) : ReportRepository {
     suspend fun getCount(): Long = queryFactory.singleQuery {
         select(count(column(Report::id)))

--- a/server/src/test/kotlin/com/fone/report/domain/repository/TestReportRepositoryImpl.kt
+++ b/server/src/test/kotlin/com/fone/report/domain/repository/TestReportRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.fone.report.domain.repository
+
+import com.fone.report.domain.entity.Report
+import com.linecorp.kotlinjdsl.querydsl.expression.column
+import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMutinyReactiveQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQuery
+import com.linecorp.kotlinjdsl.spring.reactive.SpringDataReactiveQueryFactory
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import org.hibernate.reactive.mutiny.Mutiny
+import org.hibernate.reactive.mutiny.Mutiny.Session
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Repository
+
+@Repository
+@Primary
+class TestReportRepositoryImpl(
+    private val sessionFactory: Mutiny.SessionFactory,
+    private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
+) : ReportRepository {
+    suspend fun getCount(): Long = queryFactory.singleQuery {
+        select(count(column(Report::id)))
+        from(Report::class)
+    }
+
+    suspend fun startTransaction(
+        transactionScope: suspend (RepositorySession, SpringDataReactiveQueryFactory) -> Unit,
+    ) {
+        queryFactory.transactionWithFactory { session, factory ->
+            transactionScope(RepositorySession(session), factory)
+        }
+    }
+
+    override suspend fun save(report: Report): Report {
+        return report.also {
+            queryFactory.withFactory { session, _ ->
+                if (it.id == null) {
+                    session.persist(it)
+                } else {
+                    session.merge(it)
+                }.flatMap { session.flush() }.awaitSuspending()
+            }
+        }
+    }
+
+    companion object {
+        class RepositorySession(session: Session) : Session by session
+    }
+}
+
+suspend fun TestReportRepositoryImpl.Companion.RepositorySession.save(report: Report): Report {
+    if (report.id == null) {
+        this.persist(report)
+    } else {
+        this.merge(report)
+    }.flatMap { this.flush() }.awaitSuspending()
+    return report
+}

--- a/server/src/test/kotlin/com/fone/report/domain/service/TestReportService.kt
+++ b/server/src/test/kotlin/com/fone/report/domain/service/TestReportService.kt
@@ -1,0 +1,31 @@
+package com.fone.report.domain.service
+
+import com.fone.report.domain.entity.Report
+import com.fone.report.domain.repository.TestReportRepositoryImpl
+import com.fone.report.domain.repository.save
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+@Service
+class TestReportService(
+    private val reportRepository: TestReportRepositoryImpl,
+) {
+
+    suspend fun getReportCount(): Long = reportRepository.getCount()
+
+    @Transactional
+    suspend fun createReportsAndFailWithAnnotation() {
+        reportRepository.save(Report(Random.nextLong()))
+        reportRepository.save(Report(Random.nextLong()))
+        reportRepository.save(Report(Random.nextLong()))
+        throw RuntimeException("FAIL!")
+    }
+
+    suspend fun createReportsAndFailWithTransactionalScope() = reportRepository.startTransaction { session, _ ->
+        session.save(Report(Random.nextLong()))
+        session.save(Report(Random.nextLong()))
+        session.save(Report(Random.nextLong()))
+        throw RuntimeException("FAIL!")
+    }
+}

--- a/server/src/test/kotlin/com/fone/report/domain/service/TestReportService.kt
+++ b/server/src/test/kotlin/com/fone/report/domain/service/TestReportService.kt
@@ -4,6 +4,7 @@ import com.fone.report.domain.entity.Report
 import com.fone.report.domain.repository.TestReportRepositoryImpl
 import com.fone.report.domain.repository.save
 import org.springframework.stereotype.Service
+import javax.transaction.Transactional
 import kotlin.random.Random
 
 @Service
@@ -13,13 +14,12 @@ class TestReportService(
 
     suspend fun getReportCount(): Long = reportRepository.getCount()
 
+    @Transactional
     suspend fun createReportsAndFailWithAnnotation() {
-        reportRepository.queryFactory.transactionWithFactory { _ ->
-            reportRepository.save(Report(Random.nextLong()))
-            reportRepository.save(Report(Random.nextLong()))
-            reportRepository.save(Report(Random.nextLong()))
-            throw RuntimeException("FAIL!")
-        }
+        reportRepository.save(Report(Random.nextLong()))
+        reportRepository.save(Report(Random.nextLong()))
+        reportRepository.save(Report(Random.nextLong()))
+        throw RuntimeException("FAIL!")
     }
 
     suspend fun createReportsAndFailWithTransactionalScope() = reportRepository.startTransaction { session, _ ->

--- a/server/src/test/kotlin/com/fone/report/domain/service/TestReportService.kt
+++ b/server/src/test/kotlin/com/fone/report/domain/service/TestReportService.kt
@@ -4,7 +4,6 @@ import com.fone.report.domain.entity.Report
 import com.fone.report.domain.repository.TestReportRepositoryImpl
 import com.fone.report.domain.repository.save
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import kotlin.random.Random
 
 @Service
@@ -14,12 +13,13 @@ class TestReportService(
 
     suspend fun getReportCount(): Long = reportRepository.getCount()
 
-    @Transactional
     suspend fun createReportsAndFailWithAnnotation() {
-        reportRepository.save(Report(Random.nextLong()))
-        reportRepository.save(Report(Random.nextLong()))
-        reportRepository.save(Report(Random.nextLong()))
-        throw RuntimeException("FAIL!")
+        reportRepository.queryFactory.transactionWithFactory { _ ->
+            reportRepository.save(Report(Random.nextLong()))
+            reportRepository.save(Report(Random.nextLong()))
+            reportRepository.save(Report(Random.nextLong()))
+            throw RuntimeException("FAIL!")
+        }
     }
 
     suspend fun createReportsAndFailWithTransactionalScope() = reportRepository.startTransaction { session, _ ->

--- a/server/src/test/kotlin/com/fone/report/infrastructure/ReportRepositoryImplTest.kt
+++ b/server/src/test/kotlin/com/fone/report/infrastructure/ReportRepositoryImplTest.kt
@@ -2,12 +2,14 @@ package com.fone.report.infrastructure
 
 import com.fone.common.IntegrationTest
 import com.fone.report.domain.entity.Report
+import com.fone.report.domain.service.TestReportService
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
 @IntegrationTest
 class ReportRepositoryImplTest(
     private val reportRepositoryImpl: ReportRepositoryImpl,
+    private val transactionTestingService: TestReportService,
 ) : DescribeSpec({
 
     describe("save") {
@@ -25,6 +27,24 @@ class ReportRepositoryImplTest(
             val result = reportRepositoryImpl.save(report)
 
             result shouldBe report
+        }
+    }
+    describe("transactions") {
+        it("annotation") {
+            val initialCount = transactionTestingService.getReportCount()
+            try {
+                transactionTestingService.createReportsAndFailWithAnnotation()
+            } catch (e: RuntimeException) {
+                transactionTestingService.getReportCount() shouldBe initialCount
+            }
+        }
+        it("scope") {
+            val initialCount = transactionTestingService.getReportCount()
+            try {
+                transactionTestingService.createReportsAndFailWithTransactionalScope()
+            } catch (e: RuntimeException) {
+                transactionTestingService.getReportCount() shouldBe initialCount
+            }
         }
     }
 })

--- a/server/src/test/kotlin/com/fone/report/infrastructure/ReportRepositoryImplTest.kt
+++ b/server/src/test/kotlin/com/fone/report/infrastructure/ReportRepositoryImplTest.kt
@@ -30,7 +30,7 @@ class ReportRepositoryImplTest(
         }
     }
     describe("transactions") {
-        it("context sharing") {
+        it("annotation") {
             val initialCount = transactionTestingService.getReportCount()
             try {
                 transactionTestingService.createReportsAndFailWithAnnotation()

--- a/server/src/test/kotlin/com/fone/report/infrastructure/ReportRepositoryImplTest.kt
+++ b/server/src/test/kotlin/com/fone/report/infrastructure/ReportRepositoryImplTest.kt
@@ -30,19 +30,22 @@ class ReportRepositoryImplTest(
         }
     }
     describe("transactions") {
-        it("annotation") {
+        it("context sharing") {
             val initialCount = transactionTestingService.getReportCount()
             try {
                 transactionTestingService.createReportsAndFailWithAnnotation()
             } catch (e: RuntimeException) {
+                println(transactionTestingService.getReportCount())
                 transactionTestingService.getReportCount() shouldBe initialCount
             }
+            println(transactionTestingService.getReportCount())
         }
         it("scope") {
             val initialCount = transactionTestingService.getReportCount()
             try {
                 transactionTestingService.createReportsAndFailWithTransactionalScope()
             } catch (e: RuntimeException) {
+                println(transactionTestingService.getReportCount())
                 transactionTestingService.getReportCount() shouldBe initialCount
             }
         }


### PR DESCRIPTION
기존 @Transactional과 Transactional 람다를 이용하는 방식의 차이를 테스트 코드로 반영함.

현 시점 @Transactional은 roll back가 정상적으로 작동하지 않은 상태.

람다를 이용하는 Transaction의 경우 roll back가 정상적으로 작동중.

실제 코드에 @Transactional -> 람다 형식으로 바꾸게 된다면 상당히 많은 리팩토링이 예상됨으로 일단 드래프트 형태로 PR 올립니다.

테스트 중에 @Transactional에 관한 테스트도 있어 테스트 케이스 통과 못 할 상태입니다.