### PR TITLE
[FO-65] Competition Entity의 Prize collection에 Set도 지원하도록 refactoring

### DIFF
--- a/server/src/main/kotlin/com/fone/competition/domain/entity/Competition.kt
+++ b/server/src/main/kotlin/com/fone/competition/domain/entity/Competition.kt
@@ -13,7 +13,7 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "competitions")
-data class Competition(
+class Competition(
     @Id
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,7 +33,7 @@ data class Competition(
     @OneToMany(
         mappedBy = "competition",
         cascade = [CascadeType.PERSIST]
-    ) var prizes: MutableList<Prize> = mutableListOf(),
+    ) var prizes: MutableSet<Prize> = mutableSetOf(),
 ) : BaseEntity() {
     fun view() {
         viewCount += 1
@@ -47,5 +47,20 @@ data class Competition(
     fun addPrize(prize: Prize) {
         this.prizes.add(prize)
         prize.addCompetition(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Competition
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
     }
 }

--- a/server/src/main/kotlin/com/fone/competition/domain/entity/Prize.kt
+++ b/server/src/main/kotlin/com/fone/competition/domain/entity/Prize.kt
@@ -13,7 +13,7 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "competition_prizes")
-data class Prize(
+class Prize(
     @Id
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,5 +31,20 @@ data class Prize(
 
     fun addCompetition(competition: Competition) {
         this.competition = competition
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Prize
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
     }
 }

--- a/server/src/main/kotlin/com/fone/competition/infrastructure/CompetitionRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/competition/infrastructure/CompetitionRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.linecorp.kotlinjdsl.spring.data.reactive.query.listQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.pageQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQueryOrNull
+import com.linecorp.kotlinjdsl.spring.reactive.listQuery
 import com.linecorp.kotlinjdsl.spring.reactive.querydsl.SpringDataReactiveCriteriaQueryDsl
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny
@@ -36,29 +37,30 @@ class CompetitionRepositoryImpl(
             from(entity(Competition::class))
         }.content
 
-        val competitions = queryFactory.listQuery {
-            select(entity(Competition::class))
-            from(entity(Competition::class))
-            fetch(
-                Competition::class,
-                Prize::class,
-                on(
-                    Competition::prizes
-                )
-            )
-            where(
-                and(
-                    col(Competition::id).`in`(ids),
-                    col(Competition::showStartDate).lessThanOrEqualTo(
-                        LocalDate.now()
+        val competitions = queryFactory.withFactory { factory ->
+            factory.listQuery {
+                select(entity(Competition::class))
+                from(entity(Competition::class))
+                fetch(
+                    Competition::class,
+                    Prize::class,
+                    on(
+                        Competition::prizes
                     )
                 )
-            )
-            orderBy(
-                orderSpec(pageable.sort)
-            )
+                where(
+                    and(
+                        col(Competition::id).`in`(ids),
+                        col(Competition::showStartDate).lessThanOrEqualTo(
+                            LocalDate.now()
+                        )
+                    )
+                )
+                orderBy(
+                    orderSpec(pageable.sort)
+                )
+            }
         }
-
         return PageImpl(competitions, pageable, competitions.size.toLong())
     }
 


### PR DESCRIPTION
[기존에도 갖고 계시던 문제를 봤습니다.](https://github.com/line/kotlin-jdsl/issues/179)

해당 이슈에 따라 테스트 해보려고 했으나 재현이 잘 안되더라고요

그래서 일단 눈으로 봤을 때 추측해 봤습니다.

org.hibernate.SessionException: collections cannot be fetched by a stateless session

해당 Exception은 Stateless Session으로 엔티티를 호출하고 Collection을 별도의 fetch 호출 없이 

persistence context(Lazy)에 의존해서 호출할 때 발생하는 걸로 이해했습니다.

실제 SpringDataHibernateMutinyReactiveQueryFactory 클래스에 붙어있는 extension 함수들은 모두 

Stateless Session에서 동작하게 끔 구현되어 있어, 해당 오류는 일반 Session을 사용해서 퀴리하면 될 것으로 보입니다.

즉 queryFactory.listQuery // stateless session 대신

queryFactory.withFactory { // 일반 session

으로 리팩토링 했으면 아마 해당 오류는 안 봤을 것으로 생각됩니다.

queryFactory.listQuery, queryFactory.pageQuery, queryFactory.updateQuery와 같이 stateless session을 

사용하는 퀴리들은 상당히 유의해야합니다. 

Cascade는 효과가 없으며, Lazy Fetch등 기본 hibernate 캐시(persistence context)가 필요한 기능들은 기본적으로

지원 안됩니다. 또한 Callback 호출하지 않는다고 보면 @CreateAt, @CreateBy와 같이 auditing 기능 또한 되지 않을 것으로 보입니다.

단순 조회 퀴리에는 명백한 문제가 없어보이지만, DB 변경이나 입력할 때는 stateless session 지양하는 것이 좋아보입니다.

또한 현재 구현된 @Transactional의 경우, 모두 기본 Session에 Transaction을 관리하기 때문에 

stateless session을 사용하게 되면 별도의 transaction 관리할 필요가 생길 것입니다.

근데 이 사실과 별개로, 경덕님이 올리신 코드가 왜 안되는지 잘 모르겠습니다.

 val competitions = queryFactory.listQuery {
            select(entity(Competition::class))
            from(entity(Competition::class))
            fetch(Competition::class, Prize::class, on(Competition::prizes))

해당 퀴리를 보면 fetch를 명시적으로 하기 때문에 stateless session 사용 여부과 상관 없이 되어야 하는걸로 보이며,

그래서 실제 List일 때는 정상적으로 조회가 되었으나 Set일 때는 적용이 안되는건 상당히 납득이 안되는 현상입니다.

근데 앞서 말했다시피 재현하는데 실패했음으로 일단 넘어갑니다.

그래서 현 시점에서 Competition-Prize 관계를 Set으로 표현해 봤습니다.

여기서의 문제점은 Competition와 Prize가 data class인 점인데, List는 별도의 비교 절차가 없기 때문에 문제 없이 동작하지만,

Set의 경우 비교가 필요하지만, 실제 Prize를 비교하면 data class의 equal 메소드는 constructor에 있는 

모든 파라메터로 구현되어 있다보니 Prize->Competition->Prize->Competition... 이렇게 Stack overflow가 발생합니다.

이러한 문제를 해결하기 위해 해당 엔티티들의 equal하고 hashcode를 별도로 구현했습니다.

또한 CompetitionRepositoryImpl의 경우 Competition 조회하는데 stateless session 대신에 session으로 조회해 봤습니다.

사실 해당 PR을 큰 효용이 없어 해당 글을 다 읽으셨으면 굳이 머지하지 않고 바로 Close해도 무방하다고 봅니다.


