### PR TITLE
[FO-173] Pagination 정보가 의도치 않게 행동하는 문제 수정

### DIFF
--- a/server/src/main/kotlin/com/fone/competition/domain/repository/CompetitionRepository.kt
+++ b/server/src/main/kotlin/com/fone/competition/domain/repository/CompetitionRepository.kt
@@ -1,17 +1,17 @@
 package com.fone.competition.domain.repository
 
 import com.fone.competition.domain.entity.Competition
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 
 interface CompetitionRepository {
-    suspend fun findAll(pageable: Pageable): Slice<Competition>
+    suspend fun findAll(pageable: Pageable): Page<Competition>
     suspend fun count(): Long
     suspend fun findById(competitionId: Long): Competition?
     suspend fun findScrapAllById(
         pageable: Pageable,
         userId: Long,
-    ): Slice<Competition>
+    ): Page<Competition>
 
     suspend fun save(competition: Competition): Competition
 }

--- a/server/src/main/kotlin/com/fone/competition/domain/service/RetrieveCompetitionScrapService.kt
+++ b/server/src/main/kotlin/com/fone/competition/domain/service/RetrieveCompetitionScrapService.kt
@@ -27,15 +27,14 @@ class RetrieveCompetitionScrapService(
 
         return coroutineScope {
             val competitions = async {
-                competitionRepository.findScrapAllById(pageable, userId).content
+                competitionRepository.findScrapAllById(pageable, userId)
             }
 
             val userCompetitionScraps = async { competitionScrapRepository.findByUserId(userId) }
 
             RetrieveCompetitionScrapResponse(
                 competitions.await(),
-                userCompetitionScraps.await(),
-                pageable
+                userCompetitionScraps.await()
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/competition/domain/service/RetrieveCompetitionService.kt
+++ b/server/src/main/kotlin/com/fone/competition/domain/service/RetrieveCompetitionService.kt
@@ -28,7 +28,7 @@ class RetrieveCompetitionService(
         val userId = userRepository.findByEmail(email) ?: throw NotFoundUserException()
 
         return coroutineScope {
-            val competitions = async { competitionRepository.findAll(pageable).content }
+            val competitions = async { competitionRepository.findAll(pageable) }
 
             val userCompetitionScraps = async { competitionScrapRepository.findByUserId(userId) }
 
@@ -37,8 +37,7 @@ class RetrieveCompetitionService(
             RetrieveCompetitionsResponse(
                 competitions.await(),
                 userCompetitionScraps.await(),
-                competitionCount.await(),
-                pageable
+                competitionCount.await()
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/competition/presentation/dto/RetrieveCompetitionDto.kt
+++ b/server/src/main/kotlin/com/fone/competition/presentation/dto/RetrieveCompetitionDto.kt
@@ -3,27 +3,20 @@ package com.fone.competition.presentation.dto
 import com.fone.competition.domain.entity.Competition
 import com.fone.competition.domain.entity.CompetitionScrap
 import com.fone.competition.presentation.dto.common.CompetitionDto
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Page
 
 class RetrieveCompetitionDto {
 
     data class RetrieveCompetitionsResponse(
-        val competitions: Slice<CompetitionDto>,
+        val competitions: Page<CompetitionDto>,
         val totalCount: Long,
     ) {
         constructor(
-            competitions: List<Competition>,
+            competitions: Page<Competition>,
             userCompetitionScrapMap: Map<Long, CompetitionScrap?>,
             totalCount: Long,
-            pageable: Pageable,
         ) : this(
-            competitions = PageImpl(
-                competitions.map { CompetitionDto(it, userCompetitionScrapMap) }.toList(),
-                pageable,
-                competitions.size.toLong()
-            ),
+            competitions = competitions.map { CompetitionDto(it, userCompetitionScrapMap) },
             totalCount = totalCount
         )
     }

--- a/server/src/main/kotlin/com/fone/competition/presentation/dto/RetrieveCompetitionScrapDto.kt
+++ b/server/src/main/kotlin/com/fone/competition/presentation/dto/RetrieveCompetitionScrapDto.kt
@@ -3,26 +3,18 @@ package com.fone.competition.presentation.dto
 import com.fone.competition.domain.entity.Competition
 import com.fone.competition.domain.entity.CompetitionScrap
 import com.fone.competition.presentation.dto.common.CompetitionDto
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Page
 
 class RetrieveCompetitionScrapDto {
 
     data class RetrieveCompetitionScrapResponse(
-        val competitions: Slice<CompetitionDto>,
+        val competitions: Page<CompetitionDto>,
     ) {
         constructor(
-            competitions: List<Competition>,
+            competitions: Page<Competition>,
             userCompetitionScrapMap: Map<Long, CompetitionScrap?>,
-            pageable: Pageable,
         ) : this(
-            competitions =
-            PageImpl(
-                competitions.map { CompetitionDto(it, userCompetitionScrapMap) }.toList(),
-                pageable,
-                competitions.size.toLong()
-            )
+            competitions = competitions.map { CompetitionDto(it, userCompetitionScrapMap) }
         )
     }
 }

--- a/server/src/main/kotlin/com/fone/jobOpening/domain/repository/JobOpeningRepository.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/domain/repository/JobOpeningRepository.kt
@@ -3,26 +3,26 @@ package com.fone.jobOpening.domain.repository
 import com.fone.common.entity.Type
 import com.fone.jobOpening.domain.entity.JobOpening
 import com.fone.jobOpening.presentation.dto.RetrieveJobOpeningDto.RetrieveJobOpeningsRequest
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 
 interface JobOpeningRepository {
-    suspend fun findAllTop5ByType(pageable: Pageable, type: Type): Slice<JobOpening>
+    suspend fun findAllTop5ByType(pageable: Pageable, type: Type): Page<JobOpening>
 
     suspend fun findByFilters(
         pageable: Pageable,
         type: RetrieveJobOpeningsRequest,
-    ): Slice<JobOpening>
+    ): Page<JobOpening>
 
     suspend fun findByTypeAndId(type: Type?, jobOpeningId: Long?): JobOpening?
 
-    suspend fun findAllByUserId(pageable: Pageable, userId: Long): Slice<JobOpening>
+    suspend fun findAllByUserId(pageable: Pageable, userId: Long): Page<JobOpening>
 
     suspend fun findScrapAllByUserId(
         pageable: Pageable,
         userId: Long,
         type: Type,
-    ): Slice<JobOpening>
+    ): Page<JobOpening>
 
     suspend fun save(jobOpening: JobOpening): JobOpening
 }

--- a/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveJobOpeningMyRegistrationService.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveJobOpeningMyRegistrationService.kt
@@ -31,7 +31,7 @@ class RetrieveJobOpeningMyRegistrationService(
 
         return coroutineScope {
             val jobOpenings = async {
-                jobOpeningRepository.findAllByUserId(pageable, userId).content
+                jobOpeningRepository.findAllByUserId(pageable, userId)
             }
 
             val userJobOpeningScraps = async { jobOpeningScrapRepository.findByUserId(userId) }
@@ -46,8 +46,7 @@ class RetrieveJobOpeningMyRegistrationService(
                 jobOpenings.await(),
                 userJobOpeningScraps.await(),
                 jobOpeningDomains,
-                jobOpeningCategories,
-                pageable
+                jobOpeningCategories
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveJobOpeningScrapService.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveJobOpeningScrapService.kt
@@ -33,7 +33,7 @@ class RetrieveJobOpeningScrapService(
 
         return coroutineScope {
             val jobOpenings = async {
-                jobOpeningRepository.findScrapAllByUserId(pageable, userId, type).content
+                jobOpeningRepository.findScrapAllByUserId(pageable, userId, type)
             }
 
             val userJobOpeningScraps = async { jobOpeningScrapRepository.findByUserId(userId) }
@@ -46,8 +46,7 @@ class RetrieveJobOpeningScrapService(
                 jobOpenings.await(),
                 userJobOpeningScraps.await(),
                 jobOpeningDomains,
-                jobOpeningCategories,
-                pageable
+                jobOpeningCategories
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveJobOpeningService.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveJobOpeningService.kt
@@ -36,7 +36,7 @@ class RetrieveJobOpeningService(
 
         return coroutineScope {
             val jobOpenings = async {
-                jobOpeningRepository.findByFilters(pageable, request).content
+                jobOpeningRepository.findByFilters(pageable, request)
             }
 
             val userJobOpeningScraps = async { jobOpeningScrapRepository.findByUserId(userId) }
@@ -49,8 +49,7 @@ class RetrieveJobOpeningService(
                 jobOpenings.await(),
                 userJobOpeningScraps.await(),
                 jobOpeningDomains,
-                jobOpeningCategories,
-                pageable
+                jobOpeningCategories
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveMySimilarJobOpeningService.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/domain/service/RetrieveMySimilarJobOpeningService.kt
@@ -39,7 +39,7 @@ class RetrieveMySimilarJobOpeningService(
                 "STAFF", "NORMAL" -> "STAFF"
                 else -> throw IllegalArgumentException("유효하지 않은 USER job이 존재합니다.")
             }
-            val jobOpenings = jobOpeningRepository.findAllTop5ByType(pageable, Type(jobType)).content
+            val jobOpenings = jobOpeningRepository.findAllTop5ByType(pageable, Type(jobType))
             val jobOpeningIds = jobOpenings.map { it.id!! }.toList()
             val jobOpeningDomains = jobOpeningDomainRepository.findByJobOpeningIds(jobOpeningIds)
             val jobOpeningCategories = jobOpeningCategoryRepository.findByJobOpeningIds(jobOpeningIds)
@@ -48,8 +48,7 @@ class RetrieveMySimilarJobOpeningService(
                 jobOpenings,
                 userJobOpeningScraps.await(),
                 jobOpeningDomains,
-                jobOpeningCategories,
-                pageable
+                jobOpeningCategories
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.fone.jobOpening.domain.entity.JobOpeningScrap
 import com.fone.jobOpening.domain.repository.JobOpeningRepository
 import com.fone.jobOpening.presentation.dto.RetrieveJobOpeningDto.RetrieveJobOpeningsRequest
 import com.linecorp.kotlinjdsl.query.spec.OrderSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.EqualValueSpec
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.expression.column
@@ -16,13 +17,15 @@ import com.linecorp.kotlinjdsl.spring.data.reactive.query.listQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.pageQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQueryOrNull
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.subquery
+import com.linecorp.kotlinjdsl.spring.reactive.listQuery
+import com.linecorp.kotlinjdsl.spring.reactive.pageQuery
 import com.linecorp.kotlinjdsl.spring.reactive.querydsl.SpringDataReactiveCriteriaQueryDsl
 import com.linecorp.kotlinjdsl.spring.reactive.querydsl.SpringDataReactivePageableQueryDsl
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
@@ -36,79 +39,72 @@ class JobOpeningRepositoryImpl(
     override suspend fun findAllTop5ByType(
         pageable: Pageable,
         type: Type,
-    ): Slice<JobOpening> {
-        return queryFactory.pageQuery(pageable) {
-            select(entity(JobOpening::class))
-            from(entity(JobOpening::class))
-            where(
-                and(
-                    typeEq(type),
-                    col(JobOpening::isDeleted).equal(false)
+    ): Page<JobOpening> {
+        return queryFactory.withFactory { factory ->
+            factory.pageQuery(pageable) {
+                select(entity(JobOpening::class))
+                from(entity(JobOpening::class))
+                where(
+                    and(
+                        typeEq(type),
+                        col(JobOpening::isDeleted).equal(false)
+                    )
                 )
-            )
+            }
         }
     }
 
     override suspend fun findByFilters(
         pageable: Pageable,
         request: RetrieveJobOpeningsRequest,
-    ): Slice<JobOpening> {
-        val domainJobOpeningIds = queryFactory.listQuery {
-            select(col(JobOpeningDomain::jobOpeningId))
-            from(entity(JobOpeningDomain::class))
-            where(
-                and(
-                    col(JobOpeningDomain::type).`in`(request.domains)
+    ): Page<JobOpening> {
+        return queryFactory.withFactory { factory ->
+            val domainJobOpeningIds = factory.listQuery {
+                select(col(JobOpeningDomain::jobOpeningId))
+                from(entity(JobOpeningDomain::class))
+                where(
+                    and(
+                        col(JobOpeningDomain::type).`in`(request.domains)
+                    )
                 )
-            )
-        }
+            }
 
-        val categoryJobOpeningIds = queryFactory.listQuery {
-            select(col(JobOpeningCategory::jobOpeningId))
-            from(entity(JobOpeningCategory::class))
-            where(
-                and(
-                    col(JobOpeningCategory::type).`in`(request.categories)
+            val categoryJobOpeningIds = factory.listQuery {
+                select(col(JobOpeningCategory::jobOpeningId))
+                from(entity(JobOpeningCategory::class))
+                where(
+                    and(
+                        col(JobOpeningCategory::type).`in`(request.categories)
+                    )
                 )
-            )
-        }
+            }
 
-        if (domainJobOpeningIds.isEmpty() || categoryJobOpeningIds.isEmpty()) {
-            return PageImpl(
-                listOf(),
-                pageable,
-                0
-            )
-        }
-
-        val ids = queryFactory.pageQuery(pageable) {
-            select(column(JobOpening::id))
-            from(entity(JobOpening::class))
-            where(
-                and(
-                    col(JobOpening::type).equal(request.type),
-                    col(JobOpening::gender).`in`(request.genders),
-                    or(
-                        col(JobOpening::ageMax).greaterThanOrEqualTo(request.ageMin),
-                        col(JobOpening::ageMin).lessThanOrEqualTo(request.ageMax)
-                    ),
-                    col(JobOpening::id).`in`(domainJobOpeningIds),
-                    col(JobOpening::id).`in`(categoryJobOpeningIds),
-                    col(JobOpening::isDeleted).equal(false)
+            if (domainJobOpeningIds.isEmpty() || categoryJobOpeningIds.isEmpty()) {
+                return@withFactory PageImpl(
+                    listOf(),
+                    pageable,
+                    0
                 )
-            )
-        }.content
+            }
 
-        val jobOpenings = queryFactory.listQuery {
-            select(entity(JobOpening::class))
-            from(entity(JobOpening::class))
-            where(col(JobOpening::id).`in`(ids))
-            orderBy(
-                orderSpec(pageable.sort)
-            )
+            factory.pageQuery(pageable) {
+                select(entity(JobOpening::class) as EntitySpec<JobOpening>)
+                from(entity(JobOpening::class))
+                where(
+                    and(
+                        col(JobOpening::type).equal(request.type),
+                        col(JobOpening::gender).`in`(request.genders),
+                        or(
+                            col(JobOpening::ageMax).greaterThanOrEqualTo(request.ageMin),
+                            col(JobOpening::ageMin).lessThanOrEqualTo(request.ageMax)
+                        ),
+                        col(JobOpening::id).`in`(domainJobOpeningIds),
+                        col(JobOpening::id).`in`(categoryJobOpeningIds),
+                        col(JobOpening::isDeleted).equal(false)
+                    )
+                )
+            }
         }
-
-        return PageImpl(jobOpenings, pageable, jobOpenings.size.toLong())
     }
 
     override suspend fun findByTypeAndId(
@@ -131,7 +127,7 @@ class JobOpeningRepositoryImpl(
     override suspend fun findAllByUserId(
         pageable: Pageable,
         userId: Long,
-    ): Slice<JobOpening> {
+    ): Page<JobOpening> {
         return queryFactory.pageQuery(pageable) {
             select(entity(JobOpening::class))
             from(entity(JobOpening::class))
@@ -148,7 +144,7 @@ class JobOpeningRepositoryImpl(
         pageable: Pageable,
         userId: Long,
         type: Type,
-    ): Slice<JobOpening> {
+    ): Page<JobOpening> {
         val jobOpeningIds = queryFactory.subquery {
             select(column(JobOpeningScrap::id))
             from(entity(JobOpeningScrap::class))

--- a/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveJobOpeningDto.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveJobOpeningDto.kt
@@ -8,9 +8,7 @@ import com.fone.jobOpening.domain.entity.JobOpening
 import com.fone.jobOpening.domain.entity.JobOpeningScrap
 import com.fone.jobOpening.presentation.dto.common.JobOpeningDto
 import io.swagger.annotations.ApiModelProperty
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Page
 
 class RetrieveJobOpeningDto {
 
@@ -27,28 +25,23 @@ class RetrieveJobOpeningDto {
     )
 
     data class RetrieveJobOpeningsResponse(
-        val jobOpenings: Slice<JobOpeningDto>,
+        val jobOpenings: Page<JobOpeningDto>,
     ) {
 
         constructor(
-            jobOpeningList: List<JobOpening>,
+            jobOpeningPage: Page<JobOpening>,
             userJobOpeningScrapMap: Map<Long, JobOpeningScrap?>,
             jobOpeningDomains: Map<Long, List<DomainType>>,
             jobOpeningCategories: Map<Long, List<CategoryType>>,
-            pageable: Pageable,
         ) : this(
-            jobOpenings = PageImpl(
-                jobOpeningList.map {
-                    JobOpeningDto(
-                        it,
-                        userJobOpeningScrapMap,
-                        jobOpeningDomains[it.id!!] ?: listOf(),
-                        jobOpeningCategories[it.id!!] ?: listOf()
-                    )
-                }.toList(),
-                pageable,
-                jobOpeningList.size.toLong()
-            )
+            jobOpenings = jobOpeningPage.map {
+                JobOpeningDto(
+                    it,
+                    userJobOpeningScrapMap,
+                    jobOpeningDomains[it.id!!] ?: listOf(),
+                    jobOpeningCategories[it.id!!] ?: listOf()
+                )
+            }
         )
     }
 

--- a/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveJobOpeningMyRegistrationDto.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveJobOpeningMyRegistrationDto.kt
@@ -5,35 +5,28 @@ import com.fone.common.entity.DomainType
 import com.fone.jobOpening.domain.entity.JobOpening
 import com.fone.jobOpening.domain.entity.JobOpeningScrap
 import com.fone.jobOpening.presentation.dto.common.JobOpeningDto
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Page
 
 class RetrieveJobOpeningMyRegistrationDto {
 
     data class RetrieveJobOpeningMyRegistrationResponse(
-        val jobOpenings: Slice<JobOpeningDto>,
+        val jobOpenings: Page<JobOpeningDto>,
     ) {
 
         constructor(
-            jobOpenings: List<JobOpening>,
+            jobOpenings: Page<JobOpening>,
             userJobOpeningScrapMap: Map<Long, JobOpeningScrap?>,
             jobOpeningDomains: Map<Long, List<DomainType>>,
             jobOpeningCategories: Map<Long, List<CategoryType>>,
-            pageable: Pageable,
         ) : this(
-            jobOpenings = PageImpl(
-                jobOpenings.map {
-                    JobOpeningDto(
-                        it,
-                        userJobOpeningScrapMap,
-                        jobOpeningDomains[it.id!!] ?: listOf(),
-                        jobOpeningCategories[it.id!!] ?: listOf()
-                    )
-                }.toList(),
-                pageable,
-                jobOpenings.size.toLong()
-            )
+            jobOpenings = jobOpenings.map {
+                JobOpeningDto(
+                    it,
+                    userJobOpeningScrapMap,
+                    jobOpeningDomains[it.id!!] ?: listOf(),
+                    jobOpeningCategories[it.id!!] ?: listOf()
+                )
+            }
         )
     }
 }

--- a/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveJobOpeningScrapDto.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveJobOpeningScrapDto.kt
@@ -5,35 +5,27 @@ import com.fone.common.entity.DomainType
 import com.fone.jobOpening.domain.entity.JobOpening
 import com.fone.jobOpening.domain.entity.JobOpeningScrap
 import com.fone.jobOpening.presentation.dto.common.JobOpeningDto
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
-
+import org.springframework.data.domain.Page
 class RetrieveJobOpeningScrapDto {
 
     data class RetrieveJobOpeningScrapResponse(
-        val jobOpenings: Slice<JobOpeningDto>,
+        val jobOpenings: Page<JobOpeningDto>,
     ) {
 
         constructor(
-            jobOpeningList: List<JobOpening>,
+            jobOpeningPage: Page<JobOpening>,
             userJobOpeningScrapMap: Map<Long, JobOpeningScrap?>,
             jobOpeningDomains: Map<Long, List<DomainType>>,
             jobOpeningCategories: Map<Long, List<CategoryType>>,
-            pageable: Pageable,
         ) : this(
-            jobOpenings = PageImpl(
-                jobOpeningList.map {
-                    JobOpeningDto(
-                        it,
-                        userJobOpeningScrapMap,
-                        jobOpeningDomains[it.id!!] ?: listOf(),
-                        jobOpeningCategories[it.id!!] ?: listOf()
-                    )
-                }.toList(),
-                pageable,
-                jobOpeningList.size.toLong()
-            )
+            jobOpenings = jobOpeningPage.map {
+                JobOpeningDto(
+                    it,
+                    userJobOpeningScrapMap,
+                    jobOpeningDomains[it.id!!] ?: listOf(),
+                    jobOpeningCategories[it.id!!] ?: listOf()
+                )
+            }
         )
     }
 }

--- a/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveMySimilarJobOpeningDto.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/RetrieveMySimilarJobOpeningDto.kt
@@ -5,34 +5,27 @@ import com.fone.common.entity.DomainType
 import com.fone.jobOpening.domain.entity.JobOpening
 import com.fone.jobOpening.domain.entity.JobOpeningScrap
 import com.fone.jobOpening.presentation.dto.common.JobOpeningDto
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Page
 
 class RetrieveMySimilarJobOpeningDto {
 
     data class RetrieveMySimilarJobOpeningResponse(
-        val jobOpenings: Slice<JobOpeningDto>,
+        val jobOpenings: Page<JobOpeningDto>,
     ) {
         constructor(
-            jobOpenings: List<JobOpening>,
+            jobOpenings: Page<JobOpening>,
             userJobOpeningScrapMap: Map<Long, JobOpeningScrap?>,
             jobOpeningDomains: Map<Long, List<DomainType>>,
             jobOpeningCategories: Map<Long, List<CategoryType>>,
-            pageable: Pageable,
         ) : this(
-            jobOpenings = PageImpl(
-                jobOpenings.map {
-                    JobOpeningDto(
-                        it,
-                        userJobOpeningScrapMap,
-                        jobOpeningDomains[it.id!!] ?: listOf(),
-                        jobOpeningCategories[it.id!!] ?: listOf()
-                    )
-                }.toList(),
-                pageable,
-                jobOpenings.size.toLong()
-            )
+            jobOpenings = jobOpenings.map {
+                JobOpeningDto(
+                    it,
+                    userJobOpeningScrapMap,
+                    jobOpeningDomains[it.id!!] ?: listOf(),
+                    jobOpeningCategories[it.id!!] ?: listOf()
+                )
+            }
         )
     }
 }

--- a/server/src/main/kotlin/com/fone/profile/domain/repository/ProfileRepository.kt
+++ b/server/src/main/kotlin/com/fone/profile/domain/repository/ProfileRepository.kt
@@ -3,23 +3,23 @@ package com.fone.profile.domain.repository
 import com.fone.common.entity.Type
 import com.fone.profile.domain.entity.Profile
 import com.fone.profile.presentation.dto.RetrieveProfilesDto.RetrieveProfilesRequest
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 
 interface ProfileRepository {
     suspend fun findAllByFilters(
         pageable: Pageable,
         request: RetrieveProfilesRequest,
-    ): Slice<Profile>
+    ): Page<Profile>
 
     suspend fun findByTypeAndId(type: Type?, profileId: Long?): Profile?
 
-    suspend fun findAllByUserId(pageable: Pageable, userId: Long): Slice<Profile>
+    suspend fun findAllByUserId(pageable: Pageable, userId: Long): Page<Profile>
     suspend fun save(profile: Profile): Profile
 
     suspend fun findWantAllByUserId(
         pageable: Pageable,
         userId: Long,
         type: Type,
-    ): Slice<Profile>
+    ): Page<Profile>
 }

--- a/server/src/main/kotlin/com/fone/profile/domain/service/RetrieveProfileMyRegistrationService.kt
+++ b/server/src/main/kotlin/com/fone/profile/domain/service/RetrieveProfileMyRegistrationService.kt
@@ -32,7 +32,7 @@ class RetrieveProfileMyRegistrationService(
         return coroutineScope {
             val userProfileWants = async { profileWantRepository.findByUserId(userId) }
 
-            val profiles = profileRepository.findAllByUserId(pageable, userId).content
+            val profiles = profileRepository.findAllByUserId(pageable, userId)
             val profileIds = profiles.map { it.id!! }.toList()
             val profileDomains = profileDomainRepository.findByProfileIds(profileIds)
             val profileCategories = profileCategoryRepository.findByProfileIds(profileIds)
@@ -41,8 +41,7 @@ class RetrieveProfileMyRegistrationService(
                 profiles,
                 userProfileWants.await(),
                 profileDomains,
-                profileCategories,
-                pageable
+                profileCategories
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/profile/domain/service/RetrieveProfilesService.kt
+++ b/server/src/main/kotlin/com/fone/profile/domain/service/RetrieveProfilesService.kt
@@ -35,7 +35,7 @@ class RetrieveProfilesService(
         val userId = userRepository.findByEmail(email) ?: throw NotFoundUserException()
 
         return coroutineScope {
-            val profiles = async { profileRepository.findAllByFilters(pageable, request).content }
+            val profiles = async { profileRepository.findAllByFilters(pageable, request) }
 
             val userProfileWants = async { profileWantRepository.findByUserId(userId) }
 
@@ -47,8 +47,7 @@ class RetrieveProfilesService(
                 profiles.await(),
                 userProfileWants.await(),
                 profileDomains,
-                profileCategories,
-                pageable
+                profileCategories
             )
         }
     }

--- a/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileRepositoryImpl.kt
@@ -16,12 +16,14 @@ import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMut
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.listQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.pageQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQueryOrNull
+import com.linecorp.kotlinjdsl.spring.reactive.listQuery
+import com.linecorp.kotlinjdsl.spring.reactive.pageQuery
 import com.linecorp.kotlinjdsl.spring.reactive.querydsl.SpringDataReactiveCriteriaQueryDsl
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Repository
 import javax.persistence.criteria.JoinType
@@ -35,7 +37,7 @@ class ProfileRepositoryImpl(
     override suspend fun findAllByFilters(
         pageable: Pageable,
         request: RetrieveProfilesRequest,
-    ): Slice<Profile> {
+    ): Page<Profile> {
         val categoryProfileIds = queryFactory.listQuery {
             select(col(ProfileCategory::profileId))
             from(entity(ProfileCategory::class))
@@ -66,21 +68,16 @@ class ProfileRepositoryImpl(
                     col(Profile::id).`in`(categoryProfileIds)
                 )
             )
-        }.content
+        }
 
         val profiles = queryFactory.listQuery {
             select(entity(Profile::class))
             from(entity(Profile::class))
             fetch(Profile::profileImages, joinType = JoinType.LEFT)
-            where(and(col(Profile::id).`in`(ids)))
+            where(and(col(Profile::id).`in`(ids.content)))
             orderBy(orderSpec(pageable.sort))
-        }
-
-        return PageImpl(
-            profiles,
-            pageable,
-            profiles.size.toLong()
-        )
+        }.iterator()
+        return ids.map { profiles.next() }
     }
 
     override suspend fun findByTypeAndId(type: Type?, profileId: Long?): Profile? {
@@ -95,11 +92,12 @@ class ProfileRepositoryImpl(
     override suspend fun findAllByUserId(
         pageable: Pageable,
         userId: Long,
-    ): Slice<Profile> {
+    ): Page<Profile> {
         val ids = queryFactory.pageQuery(pageable) {
             select(column(Profile::id))
             from(entity(Profile::class))
-        }.content
+            where(col(Profile::userId).equal(userId))
+        }
 
         val profiles = queryFactory.listQuery {
             select(entity(Profile::class))
@@ -107,42 +105,36 @@ class ProfileRepositoryImpl(
             fetch(Profile::profileImages, joinType = JoinType.LEFT)
             where(
                 and(
-                    col(Profile::userId).equal(userId),
-                    col(Profile::id).`in`(ids)
+                    col(Profile::id).`in`(ids.content)
                 )
             )
-        }
+        }.iterator()
 
-        return PageImpl(
-            profiles,
-            pageable,
-            profiles.size.toLong()
-        )
+        return ids.map { profiles.next() }
     }
 
     override suspend fun findWantAllByUserId(
         pageable: Pageable,
         userId: Long,
         type: Type,
-    ): Slice<Profile> {
-        val ids = queryFactory.pageQuery(pageable) {
-            select(column(ProfileWant::profileId))
-            from(entity(ProfileWant::class))
-            where(col(ProfileWant::userId).equal(userId))
-        }.content
+    ): Page<Profile> {
+        return queryFactory.withFactory { factory ->
+            val ids = factory.pageQuery(pageable) {
+                select(column(ProfileWant::profileId))
+                from(entity(ProfileWant::class))
+                join(entity(Profile::class), col(Profile::id).equal(col(ProfileWant::profileId)))
+                where(col(ProfileWant::userId).equal(userId).and(col(Profile::type).equal(type)))
+            }
 
-        val profiles = queryFactory.listQuery {
-            select(entity(Profile::class))
-            from(entity(Profile::class))
-            fetch(Profile::profileImages, joinType = JoinType.LEFT)
-            where(col(Profile::id).`in`(ids).and(col(Profile::type).equal(type)))
+            val profiles = factory.listQuery {
+                select(entity(Profile::class))
+                from(entity(Profile::class))
+                fetch(Profile::profileImages, joinType = JoinType.LEFT)
+                where(col(Profile::id).`in`(ids.content))
+            }.associateBy { it!!.id }
+
+            ids.map { profiles[it] }
         }
-
-        return PageImpl(
-            profiles,
-            pageable,
-            profiles.size.toLong()
-        )
     }
 
     override suspend fun save(profile: Profile): Profile {

--- a/server/src/main/kotlin/com/fone/profile/presentation/dto/RetrieveProfileMyRegistrationDto.kt
+++ b/server/src/main/kotlin/com/fone/profile/presentation/dto/RetrieveProfileMyRegistrationDto.kt
@@ -5,36 +5,29 @@ import com.fone.common.entity.DomainType
 import com.fone.profile.domain.entity.Profile
 import com.fone.profile.domain.entity.ProfileWant
 import com.fone.profile.presentation.dto.common.ProfileDto
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Page
 
 class RetrieveProfileMyRegistrationDto {
 
     data class RetrieveProfileMyRegistrationResponse(
-        val profiles: Slice<ProfileDto>,
+        val profiles: Page<ProfileDto>,
     ) {
 
         constructor(
-            profiles: List<Profile>,
+            profiles: Page<Profile>,
             userProfileWantMap: Map<Long, ProfileWant?>,
             profileDomains: Map<Long, List<DomainType>>,
             profileCategories: Map<Long, List<CategoryType>>,
-            pageable: Pageable,
         ) : this(
-            profiles = PageImpl(
-                profiles.map {
-                    ProfileDto(
-                        it,
-                        userProfileWantMap,
-                        it.profileImages.map { image -> image.profileUrl }.toList(),
-                        profileDomains[it.id!!] ?: listOf(),
-                        profileCategories[it.id!!] ?: listOf()
-                    )
-                }.toList(),
-                pageable,
-                profiles.size.toLong()
-            )
+            profiles = profiles.map {
+                ProfileDto(
+                    it,
+                    userProfileWantMap,
+                    it.profileImages.map { image -> image.profileUrl }.toList(),
+                    profileDomains[it.id!!] ?: listOf(),
+                    profileCategories[it.id!!] ?: listOf()
+                )
+            }
         )
     }
 }

--- a/server/src/main/kotlin/com/fone/profile/presentation/dto/RetrieveProfilesDto.kt
+++ b/server/src/main/kotlin/com/fone/profile/presentation/dto/RetrieveProfilesDto.kt
@@ -8,9 +8,7 @@ import com.fone.profile.domain.entity.Profile
 import com.fone.profile.domain.entity.ProfileWant
 import com.fone.profile.presentation.dto.common.ProfileDto
 import io.swagger.annotations.ApiModelProperty
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.Page
 
 class RetrieveProfilesDto {
 
@@ -26,28 +24,23 @@ class RetrieveProfilesDto {
     )
 
     data class RetrieveProfilesResponse(
-        val profiles: Slice<ProfileDto>,
+        val profiles: Page<ProfileDto>,
     ) {
         constructor(
-            profiles: List<Profile>,
+            profiles: Page<Profile>,
             userProfileWantMap: Map<Long, ProfileWant?>,
             profileDomains: Map<Long, List<DomainType>>,
             profileCategories: Map<Long, List<CategoryType>>,
-            pageable: Pageable,
         ) : this(
-            profiles = PageImpl(
-                profiles.map {
-                    ProfileDto(
-                        it,
-                        userProfileWantMap,
-                        it.profileImages.map { image -> image.profileUrl }.toList(),
-                        profileDomains[it.id!!] ?: listOf(),
-                        profileCategories[it.id!!] ?: listOf()
-                    )
-                }.toList(),
-                pageable,
-                profiles.size.toLong()
-            )
+            profiles = profiles.map {
+                ProfileDto(
+                    it,
+                    userProfileWantMap,
+                    it.profileImages.map { image -> image.profileUrl }.toList(),
+                    profileDomains[it.id!!] ?: listOf(),
+                    profileCategories[it.id!!] ?: listOf()
+                )
+            }
         )
     }
 


### PR DESCRIPTION
As is : Pagination 정보의 total이 Pagination 된 이후의 total 값을 돌려주도록 되어 있어 일부 Pagination 값에 오류가 생김.
To be : PageQuery의 Page 값을 그대로 활용하여 유저에게 그대로 전달되도록 한다.

추가적으로 StatelessTransaction 활용하던 일부 퀴리도 일반 Transaction으로 변경