### PR TITLE
[FO-174] job-openings, competitions, profiles 정렬 확인

### DIFF
--- a/server/src/main/kotlin/com/fone/competition/presentation/dto/common/CompetitionDto.kt
+++ b/server/src/main/kotlin/com/fone/competition/presentation/dto/common/CompetitionDto.kt
@@ -21,8 +21,10 @@ data class CompetitionDto(
     val scrapCount: Long,
     val competitionPrizes: List<CompetitionPrizeDto>,
     val isScrap: Boolean = false,
-    val dDay: String,
 ) {
+    val dDay: String
+        get() = DateTimeFormat.calculateDays(endDate ?: submitEndDate)
+
     constructor(
         competition: Competition,
         userCompetitionScrapMap: Map<Long, CompetitionScrap?>,
@@ -40,8 +42,7 @@ data class CompetitionDto(
         viewCount = competition.viewCount,
         scrapCount = competition.scrapCount,
         competitionPrizes = competition.prizes.map { CompetitionPrizeDto(it) }.toList(),
-        isScrap = userCompetitionScrapMap.get(competition.id!!) != null,
-        dDay = DateTimeFormat.calculateDays(competition.endDate ?: competition.submitEndDate)
+        isScrap = userCompetitionScrapMap.get(competition.id!!) != null
     )
 }
 

--- a/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/common/JobOpeningDto.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/presentation/dto/common/JobOpeningDto.kt
@@ -27,8 +27,9 @@ data class JobOpeningDto(
     val scrapCount: Long,
     val work: WorkDto,
     val isScrap: Boolean = false,
-    val dDay: String,
 ) {
+    val dDay: String
+        get() = DateTimeFormat.calculateDays(deadline)
 
     constructor(
         jobOpening: JobOpening,
@@ -51,7 +52,6 @@ data class JobOpeningDto(
         viewCount = jobOpening.viewCount,
         scrapCount = jobOpening.scrapCount,
         work = WorkDto(jobOpening.work),
-        isScrap = userJobOpeningScrapMap.get(jobOpening.id!!) != null,
-        dDay = DateTimeFormat.calculateDays(jobOpening.deadline)
+        isScrap = userJobOpeningScrapMap.get(jobOpening.id!!) != null
     )
 }

--- a/server/src/main/kotlin/com/fone/profile/presentation/dto/common/ProfileDto.kt
+++ b/server/src/main/kotlin/com/fone/profile/presentation/dto/common/ProfileDto.kt
@@ -8,6 +8,7 @@ import com.fone.common.utils.DateTimeFormat
 import com.fone.profile.domain.entity.Profile
 import com.fone.profile.domain.entity.ProfileWant
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class ProfileDto(
     val id: Long,
@@ -29,6 +30,7 @@ data class ProfileDto(
     val profileUrl: String,
     val isWant: Boolean = false,
     val age: Int,
+    val createdAt: LocalDateTime,
 ) {
     constructor(
         profile: Profile,
@@ -55,6 +57,7 @@ data class ProfileDto(
         viewCount = profile.viewCount,
         isWant = userProfileWantMap.get(profile.id!!) != null,
         age = DateTimeFormat.calculateAge(profile.birthday),
-        profileUrl = if (profileUrls.isEmpty()) "" else profileUrls[0]
+        profileUrl = if (profileUrls.isEmpty()) "" else profileUrls[0],
+        createdAt = profile.createdAt
     )
 }

--- a/server/src/test/kotlin/com/fone/common/PageDeserializer.kt
+++ b/server/src/test/kotlin/com/fone/common/PageDeserializer.kt
@@ -1,0 +1,34 @@
+package com.fone.common
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+// Page 역직렬화하는데 필요할 수 있음. clazz의 Page가 나타내고 있는 Class을 나타냄.
+class PageDeserializer<T : Any>(private val objectMapper: ObjectMapper, private val clazz: Class<T>) :
+    JsonDeserializer<Page<T>>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Page<T> {
+        val codec = p.codec
+        val node: JsonNode = codec.readTree(p)
+
+        val contentNode = node.get("content")
+        val content = mutableListOf<T>()
+        if (contentNode.isArray) {
+            for (item in contentNode) {
+                content.add(objectMapper.treeToValue(item, clazz))
+            }
+        }
+
+        val pageable = PageRequest.of(
+            node.get("number").asInt(),
+            node.get("size").asInt()
+        )
+
+        return PageImpl<T>(content, pageable, node.get("totalElements").asLong())
+    }
+}

--- a/server/src/test/kotlin/com/fone/jobOpening/presentation/controller/RetrieveJobOpeningControllerTest.kt
+++ b/server/src/test/kotlin/com/fone/jobOpening/presentation/controller/RetrieveJobOpeningControllerTest.kt
@@ -1,14 +1,25 @@
 package com.fone.jobOpening.presentation.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.fone.common.CommonJobOpeningCallApi
 import com.fone.common.CommonUserCallApi
 import com.fone.common.CustomDescribeSpec
 import com.fone.common.IntegrationTest
+import com.fone.common.PageDeserializer
 import com.fone.common.doGet
+import com.fone.common.response.CommonResponse
+import com.fone.jobOpening.presentation.dto.RetrieveJobOpeningDto
+import com.fone.jobOpening.presentation.dto.common.JobOpeningDto
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.data.domain.Page
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @IntegrationTest
-class RetrieveJobOpeningControllerTest(client: WebTestClient) : CustomDescribeSpec() {
+class RetrieveJobOpeningControllerTest(client: WebTestClient, private val objectMapper: ObjectMapper) :
+    CustomDescribeSpec() {
 
     private val retrieveUrl = "/api/v1/job-openings"
 
@@ -19,13 +30,8 @@ class RetrieveJobOpeningControllerTest(client: WebTestClient) : CustomDescribeSp
         describe("#retrieve jobOpenings") {
             context("구인구직 리스트를 조회하면") {
                 it("성공한다") {
-                    client
-                        .doGet(retrieveUrl, accessToken, mapOf("type" to "ACTOR"))
-                        .expectStatus().isOk
-                        .expectBody()
-                        .consumeWith { println(it) }
-                        .jsonPath("$.result")
-                        .isEqualTo("SUCCESS")
+                    client.doGet(retrieveUrl, accessToken, mapOf("type" to "ACTOR")).expectStatus().isOk.expectBody()
+                        .consumeWith { println(it) }.jsonPath("$.result").isEqualTo("SUCCESS")
                 }
             }
         }
@@ -33,25 +39,40 @@ class RetrieveJobOpeningControllerTest(client: WebTestClient) : CustomDescribeSp
         describe("#retrieve jobOpening") {
             context("존재하는 구인구직을 상세 조회하면") {
                 it("성공한다") {
-                    client
-                        .doGet("$retrieveUrl/$jobOpeningId", accessToken, mapOf("type" to "ACTOR"))
-                        .expectStatus().isOk
-                        .expectBody()
-                        .consumeWith { println(it) }
-                        .jsonPath("$.result")
+                    client.doGet("$retrieveUrl/$jobOpeningId", accessToken, mapOf("type" to "ACTOR"))
+                        .expectStatus().isOk.expectBody().consumeWith { println(it) }.jsonPath("$.result")
                         .isEqualTo("SUCCESS")
                 }
             }
 
             context("존재하지 않는 구인구직을 상세 조회하면") {
                 it("실패한다") {
-                    client
-                        .doGet("$retrieveUrl/1231", accessToken, mapOf("type" to "ACTOR"))
-                        .expectStatus().isOk
-                        .expectBody()
-                        .consumeWith { println(it) }
-                        .jsonPath("$.result")
+                    client.doGet("$retrieveUrl/1231", accessToken, mapOf("type" to "ACTOR"))
+                        .expectStatus().isOk.expectBody().consumeWith { println(it) }.jsonPath("$.result")
                         .isEqualTo("FAIL")
+                }
+            }
+        }
+        describe("#retrieve jobOpening 정렬") {
+            val pageObjectMapper = objectMapper.copy()
+            pageObjectMapper.registerModule(
+                SimpleModule().addDeserializer(
+                    Page::class.java,
+                    PageDeserializer(objectMapper, JobOpeningDto::class.java)
+                )
+            )
+            context("구인구직 정렬 조회") {
+                it("조회순 DESC") {
+                    client.doGet(retrieveUrl, accessToken, mapOf("type" to "ACTOR", "sort" to "viewCount,desc"))
+                        .expectStatus().isOk.expectBody().consumeWith {
+                            println(it)
+                            val response: CommonResponse<RetrieveJobOpeningDto.RetrieveJobOpeningsResponse> =
+                                pageObjectMapper.readValue(String(it.responseBody!!))
+                            val viewCounts = response.data?.jobOpenings?.toList()?.map { dto -> dto.viewCount }
+                            viewCounts shouldNotBe null
+                            viewCounts shouldBe viewCounts!!.sortedDescending()
+                            objectMapper
+                        }
                 }
             }
         }

--- a/server/src/test/kotlin/com/fone/profile/presentation/controller/RetrieveProfilesControllerTest.kt
+++ b/server/src/test/kotlin/com/fone/profile/presentation/controller/RetrieveProfilesControllerTest.kt
@@ -1,14 +1,25 @@
 package com.fone.profile.presentation.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.fone.common.CommonProfileCallApi
 import com.fone.common.CommonUserCallApi
 import com.fone.common.CustomDescribeSpec
 import com.fone.common.IntegrationTest
+import com.fone.common.PageDeserializer
 import com.fone.common.doGet
+import com.fone.common.response.CommonResponse
+import com.fone.profile.presentation.dto.RetrieveProfilesDto
+import com.fone.profile.presentation.dto.common.ProfileDto
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.data.domain.Page
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @IntegrationTest
-class RetrieveProfilesControllerTest(client: WebTestClient) : CustomDescribeSpec() {
+class RetrieveProfilesControllerTest(client: WebTestClient, private val objectMapper: ObjectMapper) :
+    CustomDescribeSpec() {
 
     private val retrieveUrl = "/api/v1/profiles"
 
@@ -52,6 +63,60 @@ class RetrieveProfilesControllerTest(client: WebTestClient) : CustomDescribeSpec
                         .consumeWith { println(it) }
                         .jsonPath("$.result")
                         .isEqualTo("FAIL")
+                }
+            }
+
+            context("프로파일 정렬 조회") {
+                val pageObjectMapper = objectMapper.copy()
+                pageObjectMapper.registerModule(
+                    SimpleModule().addDeserializer(
+                        Page::class.java,
+                        PageDeserializer(objectMapper, ProfileDto::class.java)
+                    )
+                )
+                it("생성시간 ASC") {
+                    client
+                        .doGet(retrieveUrl, accessToken, mapOf("type" to "ACTOR", "sort" to "createdAt"))
+                        .expectStatus().isOk
+                        .expectBody()
+                        .consumeWith {
+                            val response: CommonResponse<RetrieveProfilesDto.RetrieveProfilesResponse> =
+                                pageObjectMapper.readValue(String(it.responseBody!!))
+                            println(response)
+                            val createDates = response.data?.profiles?.toList()?.map { dto -> dto.createdAt }
+                            createDates shouldNotBe null
+                            createDates shouldBe createDates!!.sorted()
+                        }
+                }
+
+                it("생성시간 DESC") {
+                    client
+                        .doGet(retrieveUrl, accessToken, mapOf("type" to "ACTOR", "sort" to "createdAt,desc"))
+                        .expectStatus().isOk
+                        .expectBody()
+                        .consumeWith {
+                            val response: CommonResponse<RetrieveProfilesDto.RetrieveProfilesResponse> =
+                                pageObjectMapper.readValue(String(it.responseBody!!))
+                            println(response)
+                            val createDates = response.data?.profiles?.toList()?.map { dto -> dto.createdAt }
+                            createDates shouldNotBe null
+                            createDates shouldBe createDates!!.sortedDescending()
+                        }
+                }
+
+                it("조회순 DESC") {
+                    client
+                        .doGet(retrieveUrl, accessToken, mapOf("type" to "ACTOR", "sort" to "viewCount,desc"))
+                        .expectStatus().isOk
+                        .expectBody()
+                        .consumeWith {
+                            val response: CommonResponse<RetrieveProfilesDto.RetrieveProfilesResponse> =
+                                pageObjectMapper.readValue(String(it.responseBody!!))
+                            println(response)
+                            val viewCounts = response.data?.profiles?.toList()?.map { dto -> dto.viewCount }
+                            viewCounts shouldNotBe null
+                            viewCounts shouldBe viewCounts!!.sortedDescending()
+                        }
                 }
             }
         }


### PR DESCRIPTION
한결님이 해당 API에 대해 구현 요청함.

그러나 FO-173으로 pagable을 jdsl 라이브러리에 사용함으로서 별도의 구현 불필요해짐.

대신 해당 정렬에 테스트 추가.