### PR TITLE
[FO-171] 구인구직 스크랩 Response를 service영역에서 다루도록 변경

### DIFF
--- a/server/src/main/kotlin/com/fone/jobOpening/domain/service/ScrapJobOpeningService.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/domain/service/ScrapJobOpeningService.kt
@@ -5,7 +5,8 @@ import com.fone.common.exception.NotFoundUserException
 import com.fone.common.repository.UserCommonRepository
 import com.fone.jobOpening.domain.repository.JobOpeningRepository
 import com.fone.jobOpening.domain.repository.JobOpeningScrapRepository
-import com.fone.jobOpening.presentation.dto.ScrapJobOpeningDto
+import com.fone.jobOpening.presentation.dto.ScrapJobOpeningDto.ScrapJobOpeningResponse
+import com.fone.jobOpening.presentation.dto.ScrapJobOpeningDto.ScrapJobResult
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,7 +18,7 @@ class ScrapJobOpeningService(
 ) {
 
     @Transactional
-    suspend fun scrapJobOpening(email: String, jobOpeningId: Long): ScrapJobOpeningDto.ScrapJobResult {
+    suspend fun scrapJobOpening(email: String, jobOpeningId: Long): ScrapJobOpeningResponse {
         val userId = userRepository.findByEmail(email) ?: throw NotFoundUserException()
 
         jobOpeningScrapRepository.findByUserIdAndJobOpeningId(userId, jobOpeningId)?.let {
@@ -29,7 +30,7 @@ class ScrapJobOpeningService(
             jobOpening.scrapCount -= 1
 
             jobOpeningRepository.save(jobOpening)
-            return ScrapJobOpeningDto.ScrapJobResult.DISCARDED
+            return ScrapJobOpeningResponse(ScrapJobResult.DISCARDED)
         }
 
         val jobOpening = jobOpeningRepository.findByTypeAndId(null, jobOpeningId) ?: throw NotFoundJobOpeningException()
@@ -43,6 +44,6 @@ class ScrapJobOpeningService(
             )
         )
         jobOpeningRepository.save(jobOpening)
-        return ScrapJobOpeningDto.ScrapJobResult.SCRAPPED
+        return ScrapJobOpeningResponse(ScrapJobResult.SCRAPPED)
     }
 }

--- a/server/src/main/kotlin/com/fone/jobOpening/presentation/controller/ScrapJobOpeningController.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/presentation/controller/ScrapJobOpeningController.kt
@@ -2,7 +2,7 @@ package com.fone.jobOpening.presentation.controller
 
 import com.fone.common.response.CommonResponse
 import com.fone.jobOpening.application.ScrapJobOpeningFacade
-import com.fone.jobOpening.presentation.dto.ScrapJobOpeningDto
+import com.fone.jobOpening.presentation.dto.ScrapJobOpeningDto.ScrapJobOpeningResponse
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import io.swagger.v3.oas.annotations.media.Content
@@ -28,14 +28,14 @@ class ScrapJobOpeningController(
     @ApiResponse(
         responseCode = "200",
         description = "성공",
-        content = [Content(schema = Schema(implementation = ScrapJobOpeningDto.ScrapJobOpeningResponse::class))]
+        content = [Content(schema = Schema(implementation = ScrapJobOpeningResponse::class))]
     )
     suspend fun scrapJobOpening(
         principal: Principal,
         @PathVariable jobOpeningId: Long,
-    ): CommonResponse<ScrapJobOpeningDto.ScrapJobOpeningResponse> {
+    ): CommonResponse<ScrapJobOpeningResponse> {
         val response = scrapJobOpeningFacade.scrapJobOpening(principal.name, jobOpeningId)
 
-        return CommonResponse.success(ScrapJobOpeningDto.ScrapJobOpeningResponse(response))
+        return CommonResponse.success(response)
     }
 }


### PR DESCRIPTION
- 저번에 @DoodlesOnMyFood 님이 변경해주신 부분입니다.
- 어디까지나 의견이여서, 반영 여부 혹은 의견은 언제든 환영입니다.
- 단지, 다른곳에서 dto를 다루는것을 전부 service영역으로 빼다보니 통일성을 유지하고자 변경합니다. 
- 저번에 에러가 뜬다고했었는데, 여기부분에서 뜨고 있었거든요. 
   - 근데 막상, 이거 문제는 아니였고 intellij cache문제긴 했었습니다.
   - cache한번 지우고나니까 잘 되긴 하는데, 보면서 통일시키는게 어떨지 의견을 드리는게 어떤가 해서 공유드립니다 ㅎㅎ
- 여기에서 더 좋은 방향성으로 정해지면 일괄적용하는것도 좋을 것 같습니다.