### PR TITLE
[FO-229] 닉네임 유효성 검사 API에 글자수 체크 추가

### DIFF
--- a/server/src/main/kotlin/com/fone/user/presentation/controller/CheckNicknameDuplicateController.kt
+++ b/server/src/main/kotlin/com/fone/user/presentation/controller/CheckNicknameDuplicateController.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
@@ -23,6 +24,7 @@ class CheckNicknameDuplicateController(
 ) {
 
     @GetMapping("/check-nickname-duplication")
+    @PostMapping("/check-nickname")
     @ApiOperation(value = "닉네임 중복체크 API")
     @ApiResponse(
         responseCode = "200",

--- a/server/src/main/kotlin/com/fone/user/presentation/dto/CheckNicknameDuplicateDto.kt
+++ b/server/src/main/kotlin/com/fone/user/presentation/dto/CheckNicknameDuplicateDto.kt
@@ -1,12 +1,14 @@
 package com.fone.user.presentation.dto
 
 import io.swagger.annotations.ApiModelProperty
+import org.hibernate.validator.constraints.Length
 import javax.validation.constraints.NotEmpty
 
 class CheckNicknameDuplicateDto {
 
     data class CheckNicknameDuplicateRequest(
         @field:NotEmpty(message = "닉네임은 필수 값 입니다.")
+        @field:Length(min = 3, max = 8)
         @ApiModelProperty(
             value = "닉네임",
             example = "테스트닉네임",

--- a/server/src/test/kotlin/com/fone/common/CommonUserCallApi.kt
+++ b/server/src/test/kotlin/com/fone/common/CommonUserCallApi.kt
@@ -70,7 +70,7 @@ object CommonUserCallApi {
     }
 
     fun signUp(client: WebTestClient): Pair<String, String> {
-        val nickname = UUID.randomUUID().toString()
+        val nickname = UUID.randomUUID().toString().substring(0, 5)
         val email = "$nickname@test.com"
 
         val signUpUserRequest =

--- a/server/src/test/kotlin/com/fone/user/presentation/controller/CheckNicknameDuplicateControllerTest.kt
+++ b/server/src/test/kotlin/com/fone/user/presentation/controller/CheckNicknameDuplicateControllerTest.kt
@@ -17,7 +17,7 @@ class CheckNicknameDuplicateControllerTest(client: WebTestClient) : CustomDescri
         describe("#checkNicknameDuplicate") {
             context("존재하지 않는 닉네임을 입력하면") {
                 it("성공한다.") {
-                    client.doGet(checkNicknameDuplicateUrl, null, mapOf("nickname" to "1"))
+                    client.doGet(checkNicknameDuplicateUrl, null, mapOf("nickname" to "123"))
                         .expectStatus().isOk.expectBody().consumeWith { println(it) }.jsonPath("$.data.isDuplicate")
                         .isEqualTo(false)
                 }


### PR DESCRIPTION
- API네이밍이랑 역할이 조금 안맞게 됐지만, 기존 api에서도 지원이 필요해서 우선 추가해둡니다. 
- 신규 API는 post로 변경하였고, IOS분들은 해당 API로 사용 부탁드립니다.