### PR TITLE
[UPDATE] AWS default key 값 설정 추가

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -30,8 +30,8 @@ spring:
 security:
   aws:
     senderEmail: fyimbtmn@gmail.com
-    accessKey: ${AWS_ACCESS_KEY}
-    secretKey: ${AWS_SECRET_KEY}
+    accessKey: ${AWS_ACCESS_KEY:test}
+    secretKey: ${AWS_SECRET_KEY:test}
   password:
     encoder:
       secret: mysecret


### PR DESCRIPTION
- local 환경에서 세팅을 안할시에 에러뜨고 있어서, 추가합니다. 
- 로컬에서 email전송은 실제로 안되겠지만, 서버 구동은 바로 할 수 있습니다. 