### PR TITLE
[FO-672] 문자 코드 생성 버그 수정

### DIFF
--- a/server/src/main/kotlin/com/fone/user/domain/repository/MessageRepository.kt
+++ b/server/src/main/kotlin/com/fone/user/domain/repository/MessageRepository.kt
@@ -8,5 +8,5 @@ interface MessageRepository
 
 private val rng = Random(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
 fun generateRandomCode(): String {
-    return String.format("%05d", rng.nextInt(0, 1000000))
+    return String.format("%06d", rng.nextInt(0, 1000000))
 }


### PR DESCRIPTION
- 6글자여야하는데, 5글자로 전달되는 현상이 있었습니다.