### PR TITLE
[FO-770] 이메일 인증 추가 구현

### DIFF
--- a/common/src/main/kotlin/com/fone/common/exception/ServerException.kt
+++ b/common/src/main/kotlin/com/fone/common/exception/ServerException.kt
@@ -62,3 +62,7 @@ data class SMSBackendException(
 data class SMSValidationException(
     override val message: String = "인증번호가 적절하지 않음.",
 ) : ServerException(400, message)
+
+data class EmailBackendException(
+    override val message: String = "이메일 전송 오류 발생",
+) : ServerException(500, message)

--- a/server/src/main/kotlin/com/fone/filmone/config/SwaggerConfig.kt
+++ b/server/src/main/kotlin/com/fone/filmone/config/SwaggerConfig.kt
@@ -21,7 +21,6 @@ import com.fone.report.presentation.dto.RegisterReportDto.RegisterReportResponse
 import com.fone.sms.presentation.dto.SMSSendDto.SMSSendResponse
 import com.fone.user.presentation.dto.CheckNicknameDuplicateDto.CheckNicknameDuplicateResponse
 import com.fone.user.presentation.dto.EmailValidationDto.EmailDuplicationResponse
-import com.fone.user.presentation.dto.EmailValidationDto.EmailSendResponse
 import com.fone.user.presentation.dto.EmailValidationDto.EmailValidationResponse
 import com.fone.user.presentation.dto.ModifyUserDto.ModifyUserResponse
 import com.fone.user.presentation.dto.PasswordValidationDto.PasswordValidationResponse
@@ -99,7 +98,6 @@ class SwaggerConfig(
                 typeResolver.resolve(PasswordValidationResponse::class.java),
                 typeResolver.resolve(EmailDuplicationResponse::class.java),
                 typeResolver.resolve(EmailValidationResponse::class.java),
-                typeResolver.resolve(EmailSendResponse::class.java),
                 typeResolver.resolve(UserInfoSMSValidationResponse::class.java),
                 typeResolver.resolve(PasswordSMSValidationResponse::class.java),
 

--- a/server/src/main/kotlin/com/fone/user/application/EmailValidationFacade.kt
+++ b/server/src/main/kotlin/com/fone/user/application/EmailValidationFacade.kt
@@ -6,7 +6,7 @@ interface EmailValidationFacade {
 
     suspend fun sendValidationMessage(
         emailSendRequest: EmailValidationDto.EmailSendRequest,
-    ): EmailValidationDto.EmailSendResponse
+    )
 
     suspend fun validateCode(
         emailValidationRequest: EmailValidationDto.EmailValidationRequest,

--- a/server/src/main/kotlin/com/fone/user/application/EmailValidationFacadeNoOp.kt
+++ b/server/src/main/kotlin/com/fone/user/application/EmailValidationFacadeNoOp.kt
@@ -9,11 +9,10 @@ import org.springframework.stereotype.Service
 @Primary
 class EmailValidationFacadeNoOp(private val emailValidationService: EmailValidationService) : EmailValidationFacade {
 
-    override suspend fun sendValidationMessage(emailSendRequest: EmailValidationDto.EmailSendRequest) =
-        EmailValidationDto.EmailSendResponse(EmailValidationDto.ResponseType.SUCCESS)
+    override suspend fun sendValidationMessage(emailSendRequest: EmailValidationDto.EmailSendRequest) = Unit
 
     override suspend fun validateCode(emailValidationRequest: EmailValidationDto.EmailValidationRequest) =
-        EmailValidationDto.EmailValidationResponse(EmailValidationDto.ResponseType.SUCCESS, "NO-OP")
+        EmailValidationDto.EmailValidationResponse("NO-OP")
 
     override suspend fun duplicateCheck(emailDuplicationRequest: EmailValidationDto.EmailDuplicationRequest) =
         emailValidationService.checkDuplicate(emailDuplicationRequest)

--- a/server/src/main/kotlin/com/fone/user/presentation/controller/EmailValidationController.kt
+++ b/server/src/main/kotlin/com/fone/user/presentation/controller/EmailValidationController.kt
@@ -22,15 +22,14 @@ class EmailValidationController(private val emailValidationFacade: EmailValidati
     @ApiOperation(value = "인증 이메일 전송 API")
     @ApiResponse(
         responseCode = "200",
-        description = "성공",
-        content = [Content(schema = Schema(implementation = EmailValidationDto.EmailSendResponse::class))]
+        description = "성공"
     )
     suspend fun sendEmail(
         @Valid @RequestBody
         request: EmailValidationDto.EmailSendRequest,
-    ): CommonResponse<EmailValidationDto.EmailSendResponse> {
-        val response = emailValidationFacade.sendValidationMessage(request)
-        return CommonResponse.success(response)
+    ): CommonResponse<Unit> {
+        emailValidationFacade.sendValidationMessage(request)
+        return CommonResponse.success()
     }
 
     @PostMapping("/email/validate")

--- a/server/src/main/kotlin/com/fone/user/presentation/dto/EmailValidationDto.kt
+++ b/server/src/main/kotlin/com/fone/user/presentation/dto/EmailValidationDto.kt
@@ -13,10 +13,6 @@ class EmailValidationDto {
         val email: String,
     )
 
-    data class EmailSendResponse(
-        val responseType: ResponseType,
-    )
-
     data class EmailValidationRequest(
         @field:NotEmpty(message = "이메일은 필수 값 입니다.")
         @field:Email(message = "유효하지 않는 이메일 입니다.")
@@ -27,7 +23,6 @@ class EmailValidationDto {
     )
 
     data class EmailValidationResponse(
-        val responseType: ResponseType,
         val token: String,
     )
 
@@ -41,8 +36,4 @@ class EmailValidationDto {
     data class EmailDuplicationResponse(
         val email: String,
     )
-
-    enum class ResponseType {
-        SUCCESS, FAILURE
-    }
 }

--- a/server/src/main/resources/email-template.html
+++ b/server/src/main/resources/email-template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Authentication Code</title>
+    <title>회원가입 인증번호</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -40,22 +40,19 @@
 <body>
 <div class="email-container">
     <div class="email-header">
-        Your Authentication Code
+        회원가입 인증번호
     </div>
     <div class="email-content">
-        Hello,
-
-        Thank you for using our service. Please use the following authentication code to complete your sign in process.
+        에프원에 회원가입하셔서 감사합니다. 회원가입 절차를 정상적을 마치기 위해서 해당 인증번호를 회원가입 화면에 입력해주시길 바랍니다.
     </div>
     <div class="auth-code">
         AUTHENTICATION_CODE
     </div>
     <div class="email-content">
-        This code will expire in 10 minutes. If you did not request this code, please ignore this email or contact our support team.
+        해당 인증번호는 10분간 유효합니다. 만약 에프원으로 회원가입하시는게 아니라면 해당 이메일을 무시하시길 바랍니다.
     </div>
     <div class="email-footer">
-        Best Regards,
-        Your Company Name
+        에프원
     </div>
 </div>
 </body>

--- a/server/src/test/kotlin/com/fone/user/infrastructure/EmailRepositoryTest.kt
+++ b/server/src/test/kotlin/com/fone/user/infrastructure/EmailRepositoryTest.kt
@@ -4,11 +4,14 @@ import com.fone.common.IntegrationTest
 import com.fone.user.domain.repository.EmailRepository
 import com.fone.user.domain.repository.generateRandomCode
 import io.kotest.core.spec.style.ShouldSpec
+import org.springframework.beans.factory.annotation.Value
 import software.amazon.awssdk.services.ses.model.SendEmailRequest
 
 @IntegrationTest
 class EmailRepositoryTest(
     private val emailRepository: EmailRepository,
+    @Value("\${security.aws.senderEmail}")
+    private val sourceEmail: String,
 ) : ShouldSpec({
     xshould("이메일을 정상적으로 보낸다") {
         val emailTemplate =
@@ -16,13 +19,13 @@ class EmailRepositoryTest(
         val code = generateRandomCode()
         val email = "fyimbtmn@gmail.com"
         val message = SendEmailRequest.builder()
-            .source("fyimbtmn@gmail.com")
+            .source(sourceEmail)
             .destination {
                 it.toAddresses(email)
             }
             .message {
                 it.subject {
-                    it.data("인증번호입니다.")
+                    it.data("에프원 회원가입 인증번호입니다.")
                 }
                 it.body {
                     it.html {


### PR DESCRIPTION
이메일을 한글로 바꾸고 전반적으로 보내지는 이메일 보내는 이에 대한 정보 등 수정했습니다. 또한 api 일부가 CommonResponse 제대로 활용하지 않는 문제가 있어 이 또한 리팩토링했습니다.

추가적으로 secret repo에 이메일 인증 관련 환경변수 추가하고 싶은데 브랜치 및 PR 올릴 수 있는 권한 주시면 감사하겠습니다.