### PR TITLE
[FO-760] 프로필 필터 검색에 SNS 및 이미지 조회 제거

### DIFF
--- a/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileRepositoryImpl.kt
@@ -90,13 +90,16 @@ class ProfileRepositoryImpl(
         val profiles = queryFactory.listQuery {
             select(entity(Profile::class))
             from(entity(Profile::class))
-            fetch(Profile::profileImages, joinType = JoinType.LEFT)
-            fetch(Profile::snsUrls, joinType = JoinType.LEFT)
             where(and(col(Profile::id).`in`(ids.content)))
             orderBy(orderSpec(pageable.sort))
         }
 
-        val uniqueProfiles = profiles.groupBy { it?.id }.map { it.value.first() }
+        val uniqueProfiles = profiles.groupBy { it?.id }
+            .map { it.value.first() }
+            .onEach {
+                it!!.snsUrls = emptySet()
+                it.profileImages = mutableListOf()
+            }
 
         return PageImpl(
             uniqueProfiles,


### PR DESCRIPTION
프로필을 필터로 검색할 경우 해당 프로필의 이미지나 SNS 정보가 불필요하기 때문에 제거했습니다.

현재 프론트 구현이 어떻게 되어 있는지 정확히 모르기 때문에 곧 바로 적용 가능한지 의문입니다.

리뷰 후 추가적인 검토바랍니다.