### PR TITLE
[FO-1011] [프로필] 이미지가 중복으로 보이는 현상 수정

### DIFF
--- a/server/src/main/kotlin/com/fone/profile/domain/entity/Profile.kt
+++ b/server/src/main/kotlin/com/fone/profile/domain/entity/Profile.kt
@@ -39,7 +39,7 @@ data class Profile(
         mappedBy = "profile",
         cascade = [CascadeType.PERSIST, CascadeType.MERGE],
         orphanRemoval = true
-    ) var profileImages: MutableList<ProfileImage> = mutableListOf(),
+    ) var profileImages: MutableSet<ProfileImage> = mutableSetOf(),
     @Column var representativeImageUrl: String,
 
     // page3
@@ -88,7 +88,7 @@ data class Profile(
         name = request.secondPage.name
         hookingComment = request.secondPage.hookingComment
         representativeImageUrl = request.secondPage.representativeImageUrl
-        profileImages = mutableListOf()
+        profileImages = mutableSetOf()
         request.secondPage.profileImages.forEach {
             addProfileImage(ProfileImage(it))
         }
@@ -118,7 +118,7 @@ data class Profile(
         name = ""
         hookingComment = ""
         representativeImageUrl = ""
-        profileImages = mutableListOf()
+        profileImages = mutableSetOf()
         gender = null
         height = null
         weight = null

--- a/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileRepositoryImpl.kt
@@ -102,7 +102,7 @@ class ProfileRepositoryImpl(
                 .map { it.value.first() }
                 .onEach {
                     it!!.snsUrls = emptySet()
-                    it.profileImages = mutableListOf()
+                    it.profileImages = mutableSetOf()
                 }
 
         return PageImpl(
@@ -127,7 +127,7 @@ class ProfileRepositoryImpl(
         profileId: Long?,
     ): Profile? {
         return queryFactory.singleQueryOrNull {
-            select(entity(Profile::class))
+            select(distinct = true, entity(Profile::class))
             from(entity(Profile::class))
             fetch(Profile::profileImages, joinType = JoinType.LEFT)
             fetch(Profile::snsUrls, joinType = JoinType.LEFT)

--- a/server/src/main/kotlin/com/fone/profile/presentation/dto/common/ProfileDto.kt
+++ b/server/src/main/kotlin/com/fone/profile/presentation/dto/common/ProfileDto.kt
@@ -66,7 +66,7 @@ data class ProfileDto(
     constructor(
         profile: Profile,
         userProfileWantMap: Map<Long, ProfileWant?>,
-        profileImages: List<ProfileImage>,
+        profileImages: Set<ProfileImage>,
         domains: List<DomainType>?,
         categories: List<CategoryType>,
         userNickname: String,


### PR DESCRIPTION
- 원인: join으로 인해서 같은 데이터가 조회되는 현상 있었음, Set 으로 중복 데이터 제거