### PR TITLE
[FO-1037]  sql in 문에 값이 없는 경우 true으로 변환되는 문제 픽스

### DIFF
--- a/common/src/main/kotlin/com/fone/common/config/jpa/DslConfig.kt
+++ b/common/src/main/kotlin/com/fone/common/config/jpa/DslConfig.kt
@@ -1,0 +1,17 @@
+package com.fone.common.config.jpa
+
+import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.LiteralSpec
+import com.linecorp.kotlinjdsl.query.spec.predicate.EqualValueSpec
+import com.linecorp.kotlinjdsl.query.spec.predicate.InValueSpec
+import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
+
+class DslConfig
+
+fun <R> ExpressionSpec<R>.inValues(values: Collection<R>): PredicateSpec {
+    if (values.isEmpty()) {
+        // values가 없으면 항상 false이도록
+        return EqualValueSpec(LiteralSpec(1), 0)
+    }
+    return InValueSpec(this, values)
+}

--- a/common/src/main/kotlin/com/fone/common/config/jpa/JdslExt.kt
+++ b/common/src/main/kotlin/com/fone/common/config/jpa/JdslExt.kt
@@ -6,8 +6,6 @@ import com.linecorp.kotlinjdsl.query.spec.predicate.EqualValueSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.InValueSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
 
-class DslConfig
-
 fun <R> ExpressionSpec<R>.inValues(values: Collection<R>): PredicateSpec {
     if (values.isEmpty()) {
         // values가 없으면 항상 false이도록

--- a/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningCategoryRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningCategoryRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fone.jobOpening.infrastructure
 
+import com.fone.common.config.jpa.inValues
 import com.fone.common.entity.CategoryType
 import com.fone.jobOpening.domain.entity.JobOpeningCategory
 import com.fone.jobOpening.domain.repository.JobOpeningCategoryRepository
@@ -16,10 +17,7 @@ class JobOpeningCategoryRepositoryImpl(
     private val sessionFactory: Mutiny.SessionFactory,
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
 ) : JobOpeningCategoryRepository {
-
-    override suspend fun saveAll(
-        jobOpeningCategories: List<JobOpeningCategory>,
-    ): List<JobOpeningCategory> {
+    override suspend fun saveAll(jobOpeningCategories: List<JobOpeningCategory>): List<JobOpeningCategory> {
         return jobOpeningCategories.also {
             sessionFactory.withSession { session ->
                 session.persistAll(*it.toTypedArray()).flatMap { session.flush() }
@@ -33,13 +31,11 @@ class JobOpeningCategoryRepositoryImpl(
         }
     }
 
-    override suspend fun findByJobOpeningIds(
-        jobOpeningIds: List<Long>,
-    ): Map<Long, List<CategoryType>> {
+    override suspend fun findByJobOpeningIds(jobOpeningIds: List<Long>): Map<Long, List<CategoryType>> {
         return queryFactory.listQuery {
             select(entity(JobOpeningCategory::class))
             from(entity(JobOpeningCategory::class))
-            where(col(JobOpeningCategory::jobOpeningId).`in`(jobOpeningIds))
+            where(col(JobOpeningCategory::jobOpeningId).inValues(jobOpeningIds))
         }.groupBy({ it!!.jobOpeningId }, { it!!.type })
     }
 

--- a/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningDomainRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningDomainRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fone.jobOpening.infrastructure
 
+import com.fone.common.config.jpa.inValues
 import com.fone.common.entity.DomainType
 import com.fone.jobOpening.domain.entity.JobOpeningDomain
 import com.fone.jobOpening.domain.repository.JobOpeningDomainRepository
@@ -16,7 +17,6 @@ class JobOpeningDomainRepositoryImpl(
     private val sessionFactory: Mutiny.SessionFactory,
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
 ) : JobOpeningDomainRepository {
-
     override suspend fun saveAll(jobOpeningDomain: List<JobOpeningDomain>?): List<JobOpeningDomain>? {
         return jobOpeningDomain?.also {
             sessionFactory.withSession { session ->
@@ -31,13 +31,11 @@ class JobOpeningDomainRepositoryImpl(
         }
     }
 
-    override suspend fun findByJobOpeningIds(
-        jobOpeningIds: List<Long>,
-    ): Map<Long, List<DomainType>> {
+    override suspend fun findByJobOpeningIds(jobOpeningIds: List<Long>): Map<Long, List<DomainType>> {
         return queryFactory.listQuery {
             select(entity(JobOpeningDomain::class))
             from(entity(JobOpeningDomain::class))
-            where(col(JobOpeningDomain::jobOpeningId).`in`(jobOpeningIds))
+            where(col(JobOpeningDomain::jobOpeningId).inValues(jobOpeningIds))
         }.groupBy({ it!!.jobOpeningId }, { it!!.type })
     }
 

--- a/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fone.jobOpening.infrastructure
 
+import com.fone.common.config.jpa.inValues
 import com.fone.common.entity.Type
 import com.fone.jobOpening.domain.entity.JobOpening
 import com.fone.jobOpening.domain.entity.JobOpeningCategory
@@ -75,7 +76,7 @@ class JobOpeningRepositoryImpl(
                         from(entity(JobOpeningDomain::class))
                         where(
                             and(
-                                col(JobOpeningDomain::type).`in`(request.domains)
+                                col(JobOpeningDomain::type).inValues(request.domains)
                             )
                         )
                     }
@@ -90,7 +91,7 @@ class JobOpeningRepositoryImpl(
                         from(entity(JobOpeningCategory::class))
                         where(
                             and(
-                                col(JobOpeningCategory::type).`in`(request.categories)
+                                col(JobOpeningCategory::type).inValues(request.categories)
                             )
                         )
                     }
@@ -103,14 +104,20 @@ class JobOpeningRepositoryImpl(
                     where(
                         and(
                             col(JobOpening::type).equal(request.type),
-                            col(JobOpening::gender).`in`(request.genders),
+                            col(JobOpening::gender).inValues(request.genders),
                             col(JobOpening::ageMax).greaterThanOrEqualTo(request.ageMin),
                             col(JobOpening::ageMin).lessThanOrEqualTo(request.ageMax),
-                            if (request.domains.isNotEmpty()) col(JobOpening::id).`in`(domainJobOpeningIds) else null,
+                            if (request.domains.isNotEmpty()) {
+                                col(
+                                    JobOpening::id
+                                ).inValues(domainJobOpeningIds)
+                            } else {
+                                null
+                            },
                             if (request.categories.isNotEmpty()) {
                                 col(
                                     JobOpening::id
-                                ).`in`(categoryJobOpeningIds)
+                                ).inValues(categoryJobOpeningIds)
                             } else {
                                 null
                             },
@@ -133,7 +140,7 @@ class JobOpeningRepositoryImpl(
                     from(entity(JobOpening::class))
                     fetch(JobOpening::imageUrls, joinType = JoinType.LEFT)
                     fetch(JobOpening::location, joinType = JoinType.LEFT)
-                    where(and(col(JobOpening::id).`in`(jobOpeningIds.content)))
+                    where(and(col(JobOpening::id).inValues(jobOpeningIds.content)))
                     orderBy(orderSpec(pageable.sort))
                 }
 
@@ -197,7 +204,7 @@ class JobOpeningRepositoryImpl(
                     from(entity(JobOpening::class))
                     fetch(JobOpening::imageUrls, joinType = JoinType.LEFT)
                     fetch(JobOpening::location, joinType = JoinType.LEFT)
-                    where(and(col(JobOpening::id).`in`(ids.content)))
+                    where(and(col(JobOpening::id).inValues(ids.content)))
                 }.associateBy { it?.id }
 
             ids.map { jobOpenings[it] }
@@ -230,7 +237,7 @@ class JobOpeningRepositoryImpl(
                     from(entity(JobOpening::class))
                     fetch(JobOpening::imageUrls, joinType = JoinType.LEFT)
                     fetch(JobOpening::location, joinType = JoinType.LEFT)
-                    where(col(JobOpening::id).`in`(ids.content))
+                    where(col(JobOpening::id).inValues(ids.content))
                 }.associateBy { it?.id }
 
             PageImpl(

--- a/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileCategoryRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileCategoryRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fone.profile.infrastructure
 
+import com.fone.common.config.jpa.inValues
 import com.fone.common.entity.CategoryType
 import com.fone.profile.domain.entity.ProfileCategory
 import com.fone.profile.domain.repository.ProfileCategoryRepository
@@ -16,7 +17,6 @@ class ProfileCategoryRepositoryImpl(
     private val sessionFactory: Mutiny.SessionFactory,
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
 ) : ProfileCategoryRepository {
-
     override suspend fun saveAll(profileCategory: List<ProfileCategory>): List<ProfileCategory> {
         return profileCategory.also {
             sessionFactory.withSession { session ->
@@ -35,7 +35,7 @@ class ProfileCategoryRepositoryImpl(
         return queryFactory.listQuery {
             select(entity(ProfileCategory::class))
             from(entity(ProfileCategory::class))
-            where(col(ProfileCategory::profileId).`in`(profileIds))
+            where(col(ProfileCategory::profileId).inValues(profileIds))
         }.groupBy({ it!!.profileId }, { it!!.type })
     }
 

--- a/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileDomainRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/profile/infrastructure/ProfileDomainRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fone.profile.infrastructure
 
+import com.fone.common.config.jpa.inValues
 import com.fone.common.entity.DomainType
 import com.fone.profile.domain.entity.ProfileDomain
 import com.fone.profile.domain.repository.ProfileDomainRepository
@@ -16,7 +17,6 @@ class ProfileDomainRepositoryImpl(
     private val sessionFactory: Mutiny.SessionFactory,
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
 ) : ProfileDomainRepository {
-
     override suspend fun saveAll(profileDomain: List<ProfileDomain>?): List<ProfileDomain>? {
         return profileDomain?.also {
             sessionFactory.withSession { session ->
@@ -27,6 +27,7 @@ class ProfileDomainRepositoryImpl(
 
     override suspend fun deleteByProfileId(profileId: Long): Int {
         return queryFactory.deleteQuery<ProfileDomain> {
+            literal(1).equal(1)
             where(col(ProfileDomain::profileId).equal(profileId))
         }
     }
@@ -35,7 +36,7 @@ class ProfileDomainRepositoryImpl(
         return queryFactory.listQuery {
             select(entity(ProfileDomain::class))
             from(entity(ProfileDomain::class))
-            where(col(ProfileDomain::profileId).`in`(profileIds))
+            where(col(ProfileDomain::profileId).inValues(profileIds))
         }.groupBy({ it!!.profileId }, { it!!.type })
     }
 

--- a/server/src/main/kotlin/com/fone/user/infrastructure/UserRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/user/infrastructure/UserRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fone.user.infrastructure
 
+import com.fone.common.config.jpa.inValues
 import com.fone.user.domain.entity.User
 import com.fone.user.domain.enum.LoginType
 import com.fone.user.domain.repository.UserRepository
@@ -32,7 +33,7 @@ class UserRepositoryImpl(
             select(entity(User::class))
             from(entity(User::class))
             where(
-                col(User::id).`in`(userIds)
+                col(User::id).inValues(userIds)
             )
         }
     }


### PR DESCRIPTION
기존 dsl의 in문의 value 값이 [] 인 경우 해당 true로 치환되어 의도와 다르게 결과가 나오는 경우가 발생.

예시:

get /api/v1/profiles?type=ACTOR&domains=PAINTING

해당 경우 PAINTING 도메인을 가진 프로필이 존재하지 않은 경우 응답 값으로 []이 아웃풋인게 기대값이나

get /api/v1/profiles?type=ACTOR

와 같은 값을 돌려줌.