### PR TITLE
[FO-1042] 구인구직에 gender 명시되어 있지 않으면 값이 안 나오는 오류 픽스

### DIFF
--- a/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/fone/jobOpening/infrastructure/JobOpeningRepositoryImpl.kt
@@ -103,7 +103,7 @@ class JobOpeningRepositoryImpl(
                     from(entity(JobOpening::class))
                     where(
                         and(
-                            col(JobOpening::type).equal(request.type),
+                            if (request.genders.isNotEmpty()) col(JobOpening::type).equal(request.type) else null,
                             col(JobOpening::gender).inValues(request.genders),
                             col(JobOpening::ageMax).greaterThanOrEqualTo(request.ageMin),
                             col(JobOpening::ageMin).lessThanOrEqualTo(request.ageMax),


### PR DESCRIPTION
FO-1037 픽스 적용하던 과정에서 누락된 적용사항입니다. 
프로필의 경우는 해당 케이스 처리했는데 구인구직에는 적용되어 있지 않았네요.